### PR TITLE
Remove ambiguity in `fromApiToken` doc

### DIFF
--- a/src/Pinboard/Client.hs
+++ b/src/Pinboard/Client.hs
@@ -79,7 +79,7 @@ import qualified Data.Text.Encoding as T
 import Control.Applicative
 import Prelude
 
--- | Create a default PinboardConfig using the supplied apiToken
+-- | Create a default PinboardConfig using the supplied apiToken (ex: "use:ABCDEF0123456789ABCD")
 fromApiToken :: String -> PinboardConfig
 fromApiToken token =
   defaultPinboardConfig


### PR DESCRIPTION
It wasn't clear what string format I should be give to `fromApiToken`.

I searched for a function like: `fromUserAndAPIToken :: String -> String -> PinboardConfig`. But I'm not sure it will be really useful.